### PR TITLE
Fix ATmega328P clock which was not consistent with config of 1000 tick/s

### DIFF
--- a/AS6-GCC_ATmega328P/main.c
+++ b/AS6-GCC_ATmega328P/main.c
@@ -77,13 +77,14 @@ void ThreadC(void *arg)
 
 NOS_ISR(TIMER2_OVF_vect)
 {
+    TCNT2 += 6;
     nOS_Tick();
 }
 
 static void Timer2Init(void)
 {
-    TCNT2=200;
-    TCCR2B = 0b00000010;
+    TCNT2 = 6;
+    TCCR2B = 0b00000100;
     TIMSK2 = (1 << TOIE2);
 
     /* enable all interrupts */

--- a/IAR_ATmega328P/main.c
+++ b/IAR_ATmega328P/main.c
@@ -65,13 +65,14 @@ void ThreadC(void *arg)
 
 NOS_ISR(TIMER2_OVF_vect)
 {
+    TCNT2 += 6;
     nOS_Tick();
 }
 
 static void Timer2Init(void)
 {
-    TCNT2 = 200;
-    TCCR2B = 0x02;
+    TCNT2 = 6;
+    TCCR2B = 0x04;
     TIMSK2_TOIE2 = 1;
 
     /* enable all interrupts */


### PR DESCRIPTION
ATmega328P Timer2 has no automatic reload so we need to manually
reload it in the ISR. The new timer settings work with a main clock
of 16 MHz which is the default clock on some dev. boards like the
Arduino UNO. For a lower main clock, the user might need to disable
some options for keeping nOS_Tick() from bloating the whole system.
